### PR TITLE
Add `-datapoints` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ $ haggar -h
 Usage of haggar:
   -agents=100: max number of agents to run concurrently
   -carbon="localhost:2003": address of carbon host
+  -datapoints=1: number of datapoints each metrics
   -flush-interval=10s: how often to flush metrics
   -jitter=10s: max amount of jitter to introduce in between agent launches
   -metrics=10000: number of metrics for each agent to hold

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ var (
 	metrics       int
 	jitter        time.Duration
 	agents        int
+	datapoints    int
 	cacheConns    bool
 )
 
@@ -66,7 +67,7 @@ func (a *Agent) flush() error {
 
 	epoch := time.Now().Unix()
 	for _, name := range a.MetricNames {
-		err := carbonate(a.Connection, name, rand.Intn(1000), epoch)
+		err := carbonate(a.Connection, name, rand.Intn(1000), epoch, datapoints)
 		if err != nil {
 			a.Connection = nil
 			return err
@@ -96,6 +97,7 @@ func init() {
 	flag.IntVar(&metrics, "metrics", 10000, "number of metrics for each agent to hold")
 	flag.DurationVar(&jitter, "jitter", 10*time.Second, "max amount of jitter to introduce in between agent launches")
 	flag.IntVar(&agents, "agents", 100, "max number of agents to run concurrently")
+	flag.IntVar(&datapoints, "datapoints", 1, "number of datapoints each metrics")
 	flag.BoolVar(&cacheConns, "cache_connections", false, "if set, keep connections open between flushes (default: false)")
 }
 

--- a/util.go
+++ b/util.go
@@ -16,10 +16,13 @@ func genMetricNames(prefix string, id, n int) []string {
 }
 
 // actually write the data in carbon line format
-func carbonate(w io.ReadWriteCloser, name string, value int, epoch int64) error {
-	_, err := fmt.Fprintf(w, "%s %d %d\n", name, value, epoch)
-	if err != nil {
-		return err
+func carbonate(w io.ReadWriteCloser, name string, value int, epoch int64, datapoints int) error {
+	for i := 0; i < datapoints; i++ {
+		e := epoch - int64(i*60)
+		_, err := fmt.Fprintf(w, "%s %d %d\n", name, value, e)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
I want to simulate workloads that send metrics to contain multiple data points.
In `-datapoints` option is would it.