### PR TITLE
fundamental changes of implementation to give loads from a client that spawn as a worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,13 @@ $ go get github.com/gorsuch/haggar
 ```sh
 $ haggar -h
 Usage of haggar:
-  -agents=100: max number of agents to run concurrently
+  -cache_conections: if set, keep connections open between flushes
   -carbon="localhost:2003": address of carbon host
   -datapoints=1: number of datapoints each metrics
-  -flush-interval=10s: how often to flush metrics
-  -jitter=10s: max amount of jitter to introduce in between agent launches
   -metrics=10000: number of metrics for each agent to hold
   -prefix="haggar": prefix for metrics
-  -spawn-interval=10s: how often to gen new agents
+  -tasks=100: number of tasks that will pass to woker
+  -workers=100: max number of workers to run concurrently
 ```
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It behaves like a swarm of [collectd](https://collectd.org/) agents firing a fix
 ## Installation
 
 ```sh
-$ go get github.com/gorsuch/haggar
+$ go get github.com/shiimaxx/haggar
 ```
 
 ## Command-line flags

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ var (
 	carbon     string
 	prefix     string
 	metrics    int
-	agents     int
+	workers    int
 	tasks      int
 	datapoints int
 	cacheConns bool
@@ -82,7 +82,7 @@ func init() {
 	flag.StringVar(&carbon, "carbon", "localhost:2003", "address of carbon host")
 	flag.StringVar(&prefix, "prefix", "haggar", "prefix for metrics")
 	flag.IntVar(&metrics, "metrics", 10000, "number of metrics for each agent to hold")
-	flag.IntVar(&agents, "agents", 100, "max number of agents to run concurrently")
+	flag.IntVar(&workers, "workers", 100, "max number of workers to run concurrently")
 	flag.IntVar(&datapoints, "datapoints", 1, "number of datapoints each metrics")
 	flag.IntVar(&tasks, "tasks", 100, "number of tasks that will pass to woker")
 	flag.BoolVar(&cacheConns, "cache_connections", false, "if set, keep connections open between flushes (default: false)")
@@ -93,9 +93,9 @@ func main() {
 
 	log.Printf("master: pid %d\n", os.Getpid())
 
-	q := make(chan int, agents)
+	q := make(chan int, workers)
 	var wg sync.WaitGroup
-	for i := 0; i < agents; i++ {
+	for i := 0; i < workers; i++ {
 		wg.Add(1)
 		go launchAgent(&wg, q, i, metrics, carbon, prefix)
 	}

--- a/main.go
+++ b/main.go
@@ -2,148 +2,108 @@ package main
 
 import (
 	"flag"
-
-	"fmt"
 	"log"
 	"math/rand"
 	"net"
 	"os"
-	"os/signal"
-	"syscall"
+	"sync"
 	"time"
 )
 
 // config vars, to be manipulated via command line flags
 var (
-	carbon        string
-	prefix        string
-	flushInterval time.Duration
-	spawnInterval time.Duration
-	metrics       int
-	jitter        time.Duration
-	agents        int
-	datapoints    int
-	cacheConns    bool
+	carbon     string
+	prefix     string
+	metrics    int
+	agents     int
+	tasks      int
+	datapoints int
+	cacheConns bool
 )
 
-type Agent struct {
-	ID            int
-	FlushInterval time.Duration
-	Addr          string
-	MetricNames   []string
-	Connection    net.Conn
+type Worker struct {
+	ID         int
+	Addr       string
+	Connection net.Conn
 }
 
-func (a *Agent) Start() {
-	ticker := time.NewTicker(a.FlushInterval)
-	for {
-		select {
-		case <-ticker.C:
-			err := a.flush()
-			if err != nil {
-				log.Printf("agent %d: %s\n", a.ID, err)
-			}
-		}
-	}
-}
-
-func (a *Agent) flush() error {
-	if a.Connection == nil {
-		conn, err := net.Dial("tcp", a.Addr)
+func (w *Worker) Flush(taskID int, metricNames []string) error {
+	if w.Connection == nil {
+		conn, err := net.Dial("tcp", w.Addr)
 		if err != nil {
 			return err
 		}
-		a.Connection = conn
+		w.Connection = conn
 	}
 
 	if !cacheConns {
 		defer func() {
-			if a.Connection != nil {
-				a.Connection.Close()
-				a.Connection = nil
+			if w.Connection != nil {
+				w.Connection.Close()
+				w.Connection = nil
 			}
 		}()
 	}
 
 	epoch := time.Now().Unix()
-	for _, name := range a.MetricNames {
-		err := carbonate(a.Connection, name, rand.Intn(1000), epoch, datapoints)
+	for _, name := range metricNames {
+		err := carbonate(w.Connection, name, rand.Intn(1000), epoch, datapoints)
 		if err != nil {
-			a.Connection = nil
+			w.Connection = nil
 			return err
 		}
 	}
 
-	log.Printf("agent %d: flushed %d metrics\n", a.ID, len(a.MetricNames))
+	log.Printf("agent %d: flushed %d metrics for task %d\n", w.ID, len(metricNames), taskID)
 	return nil
 }
 
-func launchAgent(id, n int, flush time.Duration, addr, prefix string) {
-	metricNames := genMetricNames(prefix, id, n)
+func launchAgent(wg *sync.WaitGroup, q chan int, id, n int, addr, prefix string) {
+	defer wg.Done()
 
-	a := &Agent{
-		ID:            id,
-		FlushInterval: time.Duration(flush),
-		Addr:          addr,
-		MetricNames:   metricNames}
-	a.Start()
+	w := &Worker{
+		ID:   id,
+		Addr: addr,
+	}
+
+	for {
+		taskID, ok := <-q
+		if !ok {
+			return
+		}
+		metricNames := genMetricNames(prefix, taskID, n)
+		if err := w.Flush(taskID, metricNames); err != nil {
+			log.Printf("agent %d: %s\n", w.ID, err)
+		}
+	}
 }
 
 func init() {
 	flag.StringVar(&carbon, "carbon", "localhost:2003", "address of carbon host")
 	flag.StringVar(&prefix, "prefix", "haggar", "prefix for metrics")
-	flag.DurationVar(&flushInterval, "flush-interval", 10*time.Second, "how often to flush metrics")
-	flag.DurationVar(&spawnInterval, "spawn-interval", 10*time.Second, "how often to gen new agents")
 	flag.IntVar(&metrics, "metrics", 10000, "number of metrics for each agent to hold")
-	flag.DurationVar(&jitter, "jitter", 10*time.Second, "max amount of jitter to introduce in between agent launches")
 	flag.IntVar(&agents, "agents", 100, "max number of agents to run concurrently")
 	flag.IntVar(&datapoints, "datapoints", 1, "number of datapoints each metrics")
+	flag.IntVar(&tasks, "tasks", 100, "number of tasks that will pass to woker")
 	flag.BoolVar(&cacheConns, "cache_connections", false, "if set, keep connections open between flushes (default: false)")
 }
 
 func main() {
 	flag.Parse()
 
-	if jitter > spawnInterval {
-		flag.PrintDefaults()
-		fmt.Print("\n\nError: jitter value must be less than or equal to spawn-interval\n\n")
-		os.Exit(1)
-	}
-
-	spawnAgents := true
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGUSR1)
-
-	// start timer at 1 milli so we launch an agent right away
-	timer := time.NewTimer(1 * time.Millisecond)
-	jitterDelay := time.Duration(0)
-	curID := 0
-
 	log.Printf("master: pid %d\n", os.Getpid())
 
-	for {
-		select {
-		case <-sigChan:
-			spawnAgents = !spawnAgents
-			log.Printf("master: spawn_agents=%t\n", spawnAgents)
-		case <-timer.C:
-			if curID < agents {
-				if spawnAgents {
-					go launchAgent(curID, metrics, flushInterval, carbon, prefix)
-					log.Printf("agent %d: launched\n", curID)
-					curID++
-					// Subtract the last jitter val ue to keep spawnInterval a consistent baseline
-					nextLaunch := spawnInterval - jitterDelay
-
-					if jitter.Nanoseconds() != 0 {
-						// rand(jitter * 2) - jitter gives random +/- jitter values
-						jitterDelay = time.Duration(rand.Int63n(jitter.Nanoseconds()*2) - jitter.Nanoseconds())
-					}
-					nextLaunch += jitterDelay
-
-					timer = time.NewTimer(nextLaunch)
-				}
-			}
-		}
+	q := make(chan int, agents)
+	var wg sync.WaitGroup
+	for i := 0; i < agents; i++ {
+		wg.Add(1)
+		go launchAgent(&wg, q, i, metrics, carbon, prefix)
 	}
+
+	for i := 0; i < tasks; i++ {
+		q <- i
+	}
+	close(q)
+
+	wg.Wait()
 }

--- a/util_test.go
+++ b/util_test.go
@@ -18,7 +18,7 @@ func ExampleGenMetricNames() {
 
 func ExampleCarbonate() {
 	epoch := int64(1407850160)
-	carbonate(os.Stdout, "test.metric.1", 100, epoch)
+	carbonate(os.Stdout, "test.metric.1", 100, epoch, 1)
 	// Output:
 	// test.metric.1 100 1407850160
 }


### PR DESCRIPTION
I changed to implementation of gives loads to carbon daemon was below.

- launch workers that number of `-workers` option
- pass tasks to workers via Go`s channel
- each worker sends metrics that contains one or more data points to carbon daemon
- exit program after complete all tasks
